### PR TITLE
Npm prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "rimraf dist/ && tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json && tsc -p tsconfig.web.json",
     "pretest": "npm run build",
     "test": "echo \"It built ok, that'll do for now\"",
-    "prepack": "npm run build",
+    "prepare": "npm run build",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook -o examples"
   },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@storybook/addon-storysource": "^5.1.11",
     "@storybook/addons": "^5.1.11",
     "@storybook/react": "^5.1.11",
+    "@types/events": "^3.0.0",
     "@types/react": "^16.9.2",
     "@types/react-dom": "^16.9.0",
     "babel-loader": "^8.0.6",


### PR DESCRIPTION
This comes from a comment on issue #6 

This sets a `prepare` script in package.json, which will run on build and also anytime the repo itself is installed (either as a local clone or via something like `"dependencies": { "react-reverse-portal": "github:httptoolkit/react-reverse-portal#1fa7488" }`).

This ended up being much simpler than I realized: `prepare` is a superset of  `prepack`, so just renaming the script seems to cover all of the cases.

I also ran into an issue when trying to `npm run build` the first time after cloning the repo, due to a typescript issue: there was no declaration file for the 'events' module (which is a sub-dependency of webpack).  Installing `@types/events` fixed this, so this PR includes that change. I suspect that adding a package-lock might also fix it, but it looks like that's intentionally disabled so I didn't explore it.