### PR TITLE
Web Module changed to UMD [ES5 Support]

### DIFF
--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -3,7 +3,7 @@
     "compilerOptions": {
         "target": "es5",
         "lib": ["es6", "dom"],
-        "module": "es6",
+        "module": "UMD",
         "outDir": "./dist/web"
     }
 }


### PR DESCRIPTION
At this moment `tsconfig.web.json` is configured to not fully support **ES5**. It's configured with `"module": "es6"`. I saw that this was not possible to implement in #5.

So, now `web/index.js` has output:
```js
import * as React from 'react';
import * as ReactDOM from 'react-dom';
```

I tried to change to `UMD` and it just works.
```js
var React = require("react");
var ReactDOM = require("react-dom");
```
