### PR TITLE
Fix race conditions when swapping nodes

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -199,7 +199,7 @@ class OutPortal<C extends Component<any>> extends React.PureComponent<OutPortalP
 
         // If we're switching portal nodes, we need to clean up the current one first.
         if (this.currentPortalNode && node !== this.currentPortalNode) {
-            this.currentPortalNode.unmount();
+            this.currentPortalNode.unmount(this.placeholderNode.current!);
             this.currentPortalNode = node;
         }
 

--- a/stories/html.stories.js
+++ b/stories/html.stories.js
@@ -226,6 +226,40 @@ storiesOf('Portals', module)
             <Parent />
         </div>;
     })
+    .add("swap nodes between different locations", () => {
+        const numberOfNodes = 5;
+        const initialOrder = [];
+        for (let i = 0; i < numberOfNodes; i++) {
+          initialOrder[i] = i;
+        }
+    
+        const ExampleContent = ({ content }) => String(content);
+    
+        const ChangeLayoutWithoutUnmounting = () => {
+          const nodes = React.useMemo(
+            () => initialOrder.map(createHtmlPortalNode),
+            []
+          );
+          const [order, setOrder] = React.useState(initialOrder);
+          return (
+            <div>
+              <button onClick={() => setOrder(order.slice().reverse())}>
+                Click to reverse the order
+              </button>
+              {nodes.map((node, index) => (
+                <InPortal node={node}>
+                  <ExampleContent content={index} />
+                </InPortal>
+              ))}
+              {order.map((position) => (
+                <OutPortal node={nodes[position]} />
+              ))}
+            </div>
+          );
+        };
+    
+        return <ChangeLayoutWithoutUnmounting />;
+    })
     .add('Example from README', () => {
         const MyExpensiveComponent = () => 'expensive!';
 


### PR DESCRIPTION
The issue is described in details [here](https://github.com/httptoolkit/react-reverse-portal/issues/15). Basically, we need to make sure that unmounting a node is legitimate before actually doing it: it could have been already unmounted.

Before:
![bug](https://user-images.githubusercontent.com/29061952/94047415-5a68d280-fdd2-11ea-91f2-aeb02c042c60.gif)

After:
![works](https://user-images.githubusercontent.com/29061952/94047425-5e94f000-fdd2-11ea-84ab-aaa8b58df460.gif)

 