### PR TITLE
Avoid double-rendering InPortal child initially if props aren't overridden

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -155,7 +155,7 @@ class InPortal extends React.PureComponent<InPortalProps, { nodeProps: {} }> {
 
         return ReactDOM.createPortal(
             React.Children.map(children, (child) => {
-                if (!React.isValidElement(child)) return child;
+                if (!React.isValidElement(child) || !this.state.nodeProps) return child;
                 return React.cloneElement(child, this.state.nodeProps)
             }),
             node.element


### PR DESCRIPTION
**Bug**: The repo's description "build an element once, move it anywhere" is technically incorrect; really it's "build an element twice, move it anywhere." This PR fixes that problem :smiley: 

**Before**: https://codesandbox.io/s/affectionate-bouman-y201q?file=/src/index.tsx

**After**: https://codesandbox.io/s/bold-hoover-il7we?file=/src/react-reverse-portal.tsx