### PR TITLE
Update peerDependencies to indicate support for React 17 and 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "typescript": "^3.5.3"
   },
   "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
No functional changes: I just tested the project against React 17 and the latest alpha of React 18 (currently `18.0.0-alpha-e6be2d531`).

All of the stories and functionality seems to work fine for me locally, without any code changes, in both versions of React.