### PR TITLE
Support reverse portals in iframes and other windows.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -44,11 +44,15 @@ type AnyPortalNode<C extends Component<any> = Component<any>> = HtmlPortalNode<C
 
 
 const validateElementType = (domElement: Element, elementType: ANY_ELEMENT_TYPE) => {
+    const document = domElement.ownerDocument as any;
+    // Cast document to `any` because Typescript doesn't know about the legacy `Document.parentWindow` field, and also
+    // doesn't believe `Window.HTMLElement`/`Window.SVGElement` can be used in instanceof tests.
+    const window = document.defaultView ?? document.parentWindow; // Fallback on `parentWindow` in order to support IE8 and earlier
     if (elementType === ELEMENT_TYPE_HTML) {
-        return domElement instanceof HTMLElement;
+        return domElement instanceof window.HTMLElement;
     }
     if (elementType === ELEMENT_TYPE_SVG) {
-        return domElement instanceof SVGElement;
+        return domElement instanceof window.SVGElement;
     }
     throw new Error(`Unrecognized element type "${elementType}" for validateElementType.`);
 };


### PR DESCRIPTION
Fixes #29

Hi! Me again! It's been a while :)

With the latest versions of `react-new-window` and `react-reverse-portal` (react-new-window 1.0.1 and react-reverse-portal 2.1.1), I'm now getting the problem with exception being thrown because a DIV element is not an instanceof HTMLElement in Chrome, Firefox and Edge.

It turns out that the `HTMLElement` and `SVGElement` objects are not actually globals - they're values on the `window` object. Each window object has its own instances of those objects, which is why `instanceof` is returning false for cross-window tests. You apparently get the same behaviour if you test an element in an iframe.

So, to get it working, I've made this PR which gets the parent window of the `domElement` (using the technique described [in this stackoverflow answer](https://stackoverflow.com/a/16010322/9214694)), and then tests if `domElement instanceof window.HTMLElement` or `domElement instanceof window.SVGElement`. This works for me in the above three browsers when I tested rendering the reverse portal in a new window.

The code needs to cast things to `any` unfortunately, because Typescript doesn't know about the ancient `parentWindow` field that's needed if you want to support IE8. Even if you very reasonably don't care about that, Typescript also doesn't believe you can use `Window.HTMLElement` and `Window.SVGElement` in instanceof tests (they're interfaces as far as it's concerned).

Anyway, hopefully this change looks good to you. Let me know if you have any questions!
