### PR TITLE
Update vitest, configure tests to run in chromium

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
           node-version: 24.x
 
       - run: npm install --no-package-lock
-      - name: Install Playwright for testing
-        run: npx playwright install chromium
 
       - run: npm test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
       - run: npm install --no-package-lock
       - name: Install Playwright for testing
-        run: npx playwright install
+        run: npx playwright install chromium
 
       - run: npm test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
       - run: npm install --no-package-lock
       - name: Install Playwright for testing
-        run: npx playwright install --with-deps
+        run: npx playwright install
 
       - run: npm test
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@vitejs/plugin-react": "^5.0.4",
     "@vitest/browser": "^4.1.1",
     "@vitest/browser-playwright": "^4.1.1",
-    "playwright": "^1.55.1",
+    "playwright": "~1.58",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "rimraf": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "build": "rimraf dist/ && tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json && tsc -p tsconfig.web.json",
-    "pretest": "npm run build",
+    "pretest": "npx playwright install chromium && npm run build",
     "test": "vitest --run",
     "prepare": "npm run build",
     "storybook": "storybook dev -p 6006",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^5.0.4",
-    "@vitest/browser": "^3.2.4",
+    "@vitest/browser": "^4.1.1",
+    "@vitest/browser-playwright": "^4.1.1",
     "playwright": "^1.55.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -57,7 +58,7 @@
     "typescript": "^5.9.3",
     "vite": "^7.1.8",
     "vite-plugin-checker": "^0.11.0",
-    "vitest": "^3.2.4"
+    "vitest": "^4.1.1"
   },
   "peerDependencies": {
     "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import checker from 'vite-plugin-checker';
+import { playwright } from '@vitest/browser-playwright'
 
 export default defineConfig({
   plugins: [
@@ -13,18 +14,18 @@ export default defineConfig({
     browser: {
       enabled: true,
       headless: true,
-      provider: 'playwright',
-      screenshotFailures: false,
-      instances: [{
-        browser: 'chromium',
-        launch: {
-          channel: 'chrome',
+      provider: playwright({
+        launchOptions: {
           args: [
             '--autoplay-policy=no-user-gesture-required',
             '--disable-web-security',
             '--disable-features=IsolateOrigins,site-per-process'
           ]
         }
+      }),
+      screenshotFailures: false,
+      instances: [{
+        browser: 'chromium',
       }]
     },
     setupFiles: ['.storybook/vitest.setup.ts'],


### PR DESCRIPTION
This PR allows to run tests without system-wide Chrome browser installation.

Resolves #54 